### PR TITLE
feat: add zstd support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 This gem aims to add some exporters to [sprockets][rails/sprockets].
 
 Currently, it has:
-- a Brotli exporter, which can be used with [ngx_brotli][google/ngx_brotli].
+- a Brotli exporter, which can be used with [ngx_brotli][google/ngx_brotli] and Caddy's [file_server.precompressed] subdirective.
+- a Zstd exporter, which can be used with [zstd-nginx-module][tokers/zstd-nginx-module] and Caddy's [file_server.precompressed] subdirective.
 
 ## Installation
 
@@ -30,7 +31,10 @@ With Rails, in `application.rb`:
 
 ```ruby
 config.assets.configure do |env|
+  # Brotli
   env.register_exporter %w(text/css application/javascript image/svg+xml), Sprockets::ExportersPack::BrotliExporter
+  # Zstd
+  env.register_exporter %w(text/css application/javascript image/svg+xml), Sprockets::ExportersPack::ZstdExporter
 end
 ```
 
@@ -38,7 +42,10 @@ Without Rails:
 
 ```ruby
 env = Sprockets::Environment.new
+# Brotli
 env.register_exporter %w(text/css application/javascript image/svg+xml), Sprockets::ExportersPack::BrotliExporter
+# Zstd
+env.register_exporter %w(text/css application/javascript image/svg+xml), Sprockets::ExportersPack::ZstdExporter
 ```
 
 ## Contributing
@@ -52,3 +59,5 @@ The gem is available as open source under the terms of the [MIT License](http://
 [rails/sprockets]: https://github.com/rails/sprockets
 [rails/rails]: https://github.com/rails/rails
 [google/ngx_brotli]: https://github.com/google/ngx_brotli
+[tokers/zstd-nginx-module]: https://github.com/tokers/zstd-nginx-module
+[file_server.precompressed]: https://caddyserver.com/docs/caddyfile/directives/file_server#precompressed

--- a/lib/sprockets/exporters_pack.rb
+++ b/lib/sprockets/exporters_pack.rb
@@ -1,5 +1,6 @@
 require 'sprockets/exporters_pack/version'
 require 'sprockets/exporters_pack/brotli_exporter'
+require 'sprockets/exporters_pack/zstd_exporter'
 
 module Sprockets
   module ExportersPack

--- a/lib/sprockets/exporters_pack/zstd_exporter.rb
+++ b/lib/sprockets/exporters_pack/zstd_exporter.rb
@@ -1,0 +1,40 @@
+require 'sprockets/exporters/base'
+require 'zstd-ruby'
+
+module Sprockets
+  module ExportersPack
+    class ZstdExporter < ::Sprockets::Exporters::Base
+      def setup
+        @zstd_target = "#{ target }.zst"
+      end
+
+      def skip?(logger)
+        if ::File.exist?(@zstd_target)
+          logger.debug "Skipping #{ @zstd_target }, already exists"
+          true
+        else
+          logger.info "Writing #{ @zstd_target }"
+          false
+        end
+      end
+
+      def call
+        data = File.binread(target)
+        zstd = Zstd.compress(data, self.class.quality)
+
+        write(@zstd_target) do |file|
+          file.write(zstd)
+          file.close
+        end
+      end
+
+      class << self
+        attr_writer :quality
+
+        def quality
+          @quality || 9
+        end
+      end
+    end
+  end
+end

--- a/sprockets-exporters_pack.gemspec
+++ b/sprockets-exporters_pack.gemspec
@@ -20,5 +20,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '>= 10.0'
 
   spec.add_dependency 'brotli', '>= 0.2.0'
+  spec.add_dependency 'zstd-ruby', '~> 1.5'
   spec.add_dependency 'sprockets', '>= 4.0.0.beta3'
 end


### PR DESCRIPTION
Adds [zstd](https://facebook.github.io/zstd/) exporter.

Currently [supported](https://caniuse.com/zstd) in Chrome 123 and onward.